### PR TITLE
Added a 'deep exclusion' function 

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,10 @@ module.exports.errorLogger = function (opts) {
             err && (meta.err = err);
 
             var json = meta;
-            if (excludes) {
+            if (excludes && !util.isArray(excludes)) {
+                json = deepExclude(excludes, meta);
+            }
+            else {
                 json = null;
                 if (!~excludes.indexOf('*')) {
                     json = {};
@@ -157,6 +160,33 @@ module.exports.errorLogger = function (opts) {
     };
 };
 
+function deepExclude(excludes, meta) {
+
+    json = meta;
+    for(var q in excludes) {
+
+        if (!util.isArray(excludes[q])) {
+            json = deepExclude(excludes[q], meta[q]);
+        }
+        else {
+            jsub = null;
+            if (!~excludes[q].indexOf('*')) {
+                jsub = {};
+                var exs = {};
+                excludes[q].forEach(function(ex) {
+                    exs[ex] = true;
+                });
+                for (var p in meta[q]) {
+                    if (!exs[p]) {
+                      jsub[p] = meta[q][p];
+                    }
+                }
+            }
+            json[q] = jsub;
+        }
+    }
+    return json;
+}
 
 function compile(fmt) {
     fmt = fmt.replace(/"/g, '\\"');


### PR DESCRIPTION
Which allows specific properties of sub-objects to be uniquely chosen for exclusion.

We required this functionality to exclude potentially sensitive information from logs such as authorization tokens, or passwords send with authentication requests. The current excludes feature does not allow for partial logging of meta data, and we did not want to exclude the entire 'body' but just sensitive parts of it.


Note that the current excludes functionality is preserved.


To exclude object properties on a deeper level, an object can be passed as the excludes option:

``` javascript
        app.use(require('express-bunyan-logger')({
            logger: newLogger,
            excludes: {'body':['password']}
        }));
```

The function searches the object hierarchy provided and excludes only those properties specified in the base list. In the case above, any body properties called password will be removed. The "*" feature of the previous functionality is also preserved on sub-levels. The search is recursive, so more than one level can be specified.