### PR TITLE
Pass meta to level fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,16 @@ Whether to parse _user-agent_ in logger, default is =true=.
 
 ### options.levelFn
 
-Function that translate statusCode into log level.
+Function that translate statusCode into log level. The `meta` argument is an object consisting of all the fields gathered by bunyan-express-logger, before exclusions are applied. 
 
 ```
-function(status, err /* only will work in error logger */) {
+function(status, err /* only will work in error logger */, meta) {
      // return string of level
-     return "info";
+     if (meta["response-time"] > 30000) {
+         return "fatal";
+     } else {
+         return "info";
+     }
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -97,9 +97,6 @@ module.exports.errorLogger = function (opts) {
                 responseTime = hrtime[0] * 1e3 + hrtime[1] / 1e6,
                 ip, logFn;
 
-            var level = levelFn(status, err);
-            logFn = childLogger[level] ? childLogger[level] : childLogger.info;
-
             ip = ip || req.ip || req.connection.remoteAddress ||
                 (req.socket && req.socket.remoteAddress) ||
                 (req.socket.socket && req.socket.socket.remoteAddress) ||
@@ -126,6 +123,9 @@ module.exports.errorLogger = function (opts) {
             };
 
             err && (meta.err = err);
+
+            var level = levelFn(status, err, meta);
+            logFn = childLogger[level] ? childLogger[level] : childLogger.info;
 
             var json = meta;
             if (excludes) {

--- a/test/bunyan.test.js
+++ b/test/bunyan.test.js
@@ -268,6 +268,31 @@ describe('bunyan-logger', function() {
           done();
         });
   });
+
+  it('test options.levelFn', function (done) {
+    var app = express();
+    var output = st();
+    app.use(bunyanLogger({
+      stream: output,
+      levelFn: function (status, err, meta) {
+        if (meta && meta['response-time'] !== undefined) {
+          return 'fatal';
+        }
+      }
+    }));
+
+    app.get('/', function (req, res) {
+      res.send('GET /');
+    });
+
+    request(app)
+        .get('/')
+        .expect('error level fatal', function (err, res) {
+          var json = JSON.parse(output.content.toString());
+          assert.equal(json.level, 60);
+          done();
+        });
+  });
 });
 
 


### PR DESCRIPTION
Passing `meta` object constructed for bunyan log function to `levelFn`. This provides more information for determining log level to use.