### PR TITLE
added an includesFn option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ function(status, err /* only will work in error logger */) {
 }
 ```
 
+### options.includesFn
+
+Function that is passed `req` and `res`, and returns an object whose properties will be added to the meta object passed to bunyan
+
+```javascript
+function(req, res) {
+    if (req.user) {
+        return {
+            _id: req.user._id,
+            name: req.user.name
+        }
+    }
+}
+```
+
 ### options.excludes
 
 Array of string, Those fields will be excluded from meta object which passed to bunyan

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports.errorLogger = function (opts) {
         parseUA = true,
         excludes,
         genReqId = defaultGenReqId,
-        levelFn = defaultLevelFn;
+        levelFn = defaultLevelFn,
+        includesFn;
 
     if (opts.logger) {
       logger = opts.logger;
@@ -44,6 +45,11 @@ module.exports.errorLogger = function (opts) {
     if (opts.excludes) {
         excludes = opts.excludes;
         delete opts.excludes;
+    }
+
+    if (opts.includesFn) {
+        includesFn = opts.includesFn;
+        delete opts.includesFn;
     }
 
 
@@ -134,6 +140,16 @@ module.exports.errorLogger = function (opts) {
                     for (var p in meta) 
                         if (!exs[p])
                           json[p] = meta[p];
+                }
+            }
+
+            if (includesFn) {
+                var includes = includesFn(req, res);
+
+                if (includes) {
+                    for (var p in includes) {
+                        json[p] = includes[p];
+                    }
                 }
             }
 

--- a/test/bunyan.test.js
+++ b/test/bunyan.test.js
@@ -239,6 +239,35 @@ describe('bunyan-logger', function() {
         done();
       });
   });
+
+  it('test options.includesFn', function (done) {
+    var app = express();
+    var output = st();
+    app.use(bunyanLogger({
+      stream: output,
+      includesFn: function (req, res) {
+        return {
+          user: {
+            name: 'Eric',
+            _id: '546f80240a186fd6181472a9'
+          }
+        };
+      }
+    }));
+
+    app.get('/', function (req, res) {
+      res.send('GET /');
+    });
+
+    request(app)
+        .get('/')
+        .expect('user property to be present in log', function (err, res) {
+          var json = JSON.parse(output.content.toString());
+          assert(json.user);
+          assert.equal(json.user.name, 'Eric');
+          done();
+        });
+  });
 });
 
 


### PR DESCRIPTION
`includesFn` option is called after the meta object passed to the bunyan log function is constructed (after excludes are applied). It is passed req and res and returns an object. The properties of the object returned are added to the meta object.

Note: if you decide to accept my other pull request (https://github.com/villadora/express-bunyan-logger/pull/30), I can rebase this branch onto the merged changes in master as there will be conflicts in `test/bunyan.test.js`