### PR TITLE
Fixed immediate to only log immediately

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,11 +163,10 @@ module.exports.errorLogger = function (opts) {
 
         if (immediate) {
             logging(true);
+        } else {
+            res.on('finish', logging);
+            res.on('close', logging);
         }
-
-        res.on('finish', logging);
-        res.on('close', logging);
-
 
         next(err);
     };


### PR DESCRIPTION
Without this fix it will log immediately and then at the end of the response.