### PR TITLE
fix req.headers from always becoming "[CIRCULAR]"

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ module.exports.errorLogger = function (opts) {
                 'response-time': responseTime,
                 "response-hrtime": hrtime,
                 "status-code": status,
-                'req-headers': req.headers,
+                'req-headers': JSON.parse(JSON.stringify(req.headers)),
                 'res-headers': res._headers,
                 'req': req,
                 'res': res,


### PR DESCRIPTION
req-headers is always "[CIRCULAR]" due to Bunyan's safeCycle() during JSON.stringify. Deep clone req.headers to req-header to overcome the same object check in safeCycle()