### PR TITLE
Depreciation Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-bunyan-logger",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "a bunyan logger middleware for express",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,7 @@
     "bunyan": "^1.8.1",
     "lodash.has": "^4.5.1",
     "lodash.set": "^4.3.1",
-    "node-uuid": "^1.4.7",
+    "uuid": "^3.0.0",
     "useragent": "^2.1.9"
   },
   "devDependencies": {
@@ -42,5 +42,5 @@
     "Ognian Tschakalov <ognian.tschakalov@ogi-it.com>",
     "Simon Wade <simon.wade@gmail.com>"
   ],
-  "license": "BSD"
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
- `node-uuid 1.4.7` => `uuid 3.0.0`
- License requires SPDX string now.