### PR TITLE
Allow user to rename req_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ app.use(require('express-bunyan-logger')({
 });
 ```
 
+If you don't want the ID to be saved as `req_id` in the logger, you can supply an alternative name through `options.reqId`:
+
+```javascript
+app.use(require('express-bunyan-logger')({
+    genReqId: function(req) {
+       return req.id;
+    },
+    reqId: 'requestId'
+});
+```
+
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports.errorLogger = function (opts) {
         obfuscate,
         obfuscatePlaceholder,
         genReqId = defaultGenReqId,
+        reqId = 'req_id',
         levelFn = defaultLevelFn,
         includesFn;
 
@@ -66,8 +67,14 @@ module.exports.errorLogger = function (opts) {
 
     if (opts.genReqId) {
         genReqId = typeof genReqId == 'function' ? opts.genReqId : defaultGenReqId;
+
     }else if (opts.hasOwnProperty('genReqId')) {
         genReqId = false;
+    }
+
+    if (opts.reqId) {
+        reqId = opts.reqId;
+        delete opts.reqId;
     }
 
     return function (err, req, res, next) {
@@ -85,11 +92,14 @@ module.exports.errorLogger = function (opts) {
         }
 
         var requestId;
+        var loggerConfig = Object.create(null);
 
-        if (genReqId)
+        if (genReqId) {
           requestId = genReqId(req);
+          loggerConfig[reqId] = requestId;
+        }
 
-        var childLogger = requestId !== undefined ? logger.child({req_id: requestId}) : logger;
+        var childLogger = requestId !== undefined ? logger.child(loggerConfig) : logger;
         req.log = childLogger;
 
         function logging(incoming) {


### PR DESCRIPTION
This allows users of the middleware to define the name of the request ID in the logger.

The label should be provided through the `reqId` setting in the options hash.