### PR TITLE
More robust npm scripts setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "a bunyan logger middleware for express",
   "main": "index.js",
   "scripts": {
-    "lint": "./node_modules/.bin/jshint index.js test/*.js",
-    "test": "npm run lint && ./node_modules/.bin/mocha -R spec"
+    "lint": "jshint index.js test/*.js",
+    "test": "npm run lint && mocha -R spec"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Specifying an absolute path is no longer required. npm now figures out the proper path, which also resolves issues on non-POSIX OS.