### PR TITLE
Default to standard error serializer for non-error middleware.

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ module.exports.errorLogger = function (opts) {
             opts.serializers = opts.serializers || {};
             opts.serializers.req = opts.serializers.req || bunyan.stdSerializers.req;
             opts.serializers.res = opts.serializers.res || bunyan.stdSerializers.res;
-            err && (opts.serializers.err = opts.serializers.err || bunyan.stdSerializers.err);
+            opts.serializers.err = opts.serializers.err || bunyan.stdSerializers.err;
             logger = bunyan.createLogger(opts);
         }
 


### PR DESCRIPTION
The `err` serializer was not defaulting to the standard Error serializer provided by bunyan when there was no error instance.
In practice this means it won't be set for the logger created by the default middleware.

It seems common practice to log an error when processing a request then not let it bubble up to an error middleware. However, in that case the resulting log unexpectedly logs `err: {}`.