### PR TITLE
Eliminate Node12 header deprecation warning (DEP0066)

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ module.exports.errorLogger = function (opts) {
                 "response-hrtime": hrtime,
                 "status-code": status,
                 'req-headers': req.headers,
-                'res-headers': res._headers,
+                'res-headers': res.getHeaders(),
                 'req': req,
                 'res': res,
                 'incoming':incoming?'-->':'<--'

--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@ var bunyan = require('bunyan'),
     useragent = require('useragent'),
     uuid = require('uuid'),
     util = require('util'),
-    semver = require('semver');
+    gte = require('semver.gte');
 
 // with Node 12, res._headers becomes deprecated DEP-0066
-var useGetHeader = (process && semver.gte(process.versions.node, '12.0.0'));
+var useGetHeader = (process && gte(process.versions.node, '12.0.0'));
 
 module.exports = function (opts) {
     var logger = module.exports.errorLogger(opts);

--- a/index.js
+++ b/index.js
@@ -3,8 +3,11 @@ var bunyan = require('bunyan'),
     set = require('lodash.set'),
     useragent = require('useragent'),
     uuid = require('uuid'),
-    util = require('util');
+    util = require('util'),
+    semver = require('semver');
 
+// with Node 12, res._headers becomes deprecated DEP-0066
+var useGetHeader = (process && semver.gte(process.versions.node, '12.0.0'));
 
 module.exports = function (opts) {
     var logger = module.exports.errorLogger(opts);
@@ -127,7 +130,7 @@ module.exports.errorLogger = function (opts) {
                 "response-hrtime": hrtime,
                 "status-code": status,
                 'req-headers': req.headers,
-                'res-headers': res.getHeaders(),
+                'res-headers': useGetHeader ? res.getHeaders() : res._headers,
                 'req': req,
                 'res': res,
                 'incoming':incoming?'-->':'<--'

--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@ var bunyan = require('bunyan'),
     useragent = require('useragent'),
     uuid = require('uuid'),
     util = require('util'),
-    gte = require('semver.gte');
+    semver = require('semver');
 
 // with Node 12, res._headers becomes deprecated DEP-0066
-var useGetHeader = (process && gte(process.versions.node, '12.0.0'));
+var useGetHeader = (process && semver.gte(process.versions.node, '12.0.0'));
 
 module.exports = function (opts) {
     var logger = module.exports.errorLogger(opts);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bunyan": "^1.8.12",
     "lodash.has": "^4.5.2",
     "lodash.set": "^4.3.2",
-    "semver.gte": "^6.3.0",
+    "semver": "^6.3.0",
     "useragent": "^2.2.1",
     "uuid": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bunyan": "^1.8.12",
     "lodash.has": "^4.5.2",
     "lodash.set": "^4.3.2",
+    "semver.gte": "^6.3.0",
     "useragent": "^2.2.1",
     "uuid": "^3.1.0"
   },


### PR DESCRIPTION
https://nodejs.org/api/deprecations.html#deprecations_dep0066_outgoingmessage_prototype_headers_outgoingmessage_prototype_headernames